### PR TITLE
feat(helm): allow external memcached setup

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1893,6 +1893,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>chunksCache.addresses</td>
+			<td>string</td>
+			<td>Comma separated addresses list in DNS Service Discovery format</td>
+			<td><pre lang="json">
+"dnssrvnoa+_memcached-client._tcp.{{ template \\\"loki.fullname\\\" $ }}-chunks-cache.{{ $.Release.Namespace }}.svc"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>chunksCache.affinity</td>
 			<td>object</td>
 			<td>Affinity for chunks-cache pods</td>
@@ -1925,6 +1934,15 @@ null
 			<td>Batchsize for sending and receiving chunks from chunks cache</td>
 			<td><pre lang="json">
 4
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>chunksCache.clientService</td>
+			<td>string</td>
+			<td>SRV service used to discover memcache servers.</td>
+			<td><pre lang="json">
+"memcached"
 </pre>
 </td>
 		</tr>
@@ -1997,6 +2015,15 @@ true
 			<td>Additional volumes to be added to the chunks-cache pod (applies to both memcached and exporter containers). Example: extraVolumes: - name: extra-volume   secret:    secretName: extra-volume-secret</td>
 			<td><pre lang="json">
 []
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>chunksCache.host</td>
+			<td>string</td>
+			<td>Hostname for memcached service to use.</td>
+			<td><pre lang="json">
+""
 </pre>
 </td>
 		</tr>
@@ -6875,6 +6902,15 @@ false
 </td>
 		</tr>
 		<tr>
+			<td>memcached.enabled</td>
+			<td>bool</td>
+			<td>Enable the built in memcached server provided by the chart</td>
+			<td><pre lang="json">
+true
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>memcached.image.pullPolicy</td>
 			<td>string</td>
 			<td>Memcached Docker image pull policy</td>
@@ -10142,6 +10178,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>resultsCache.addresses</td>
+			<td>string</td>
+			<td>Comma separated addresses list in DNS Service Discovery format</td>
+			<td><pre lang="json">
+"dnssrvnoa+_memcached-client._tcp.{{ template \"loki.fullname\" $ }}-results-cache.{{ $.Release.Namespace }}.svc"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>resultsCache.affinity</td>
 			<td>object</td>
 			<td>Affinity for results-cache pods</td>
@@ -10165,6 +10210,15 @@ null
 			<td>Annotations for the results-cache pods</td>
 			<td><pre lang="json">
 {}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>resultsCache.clientService</td>
+			<td>string</td>
+			<td>SRV service used to discover memcache servers.</td>
+			<td><pre lang="json">
+"memcached"
 </pre>
 </td>
 		</tr>
@@ -10237,6 +10291,15 @@ true
 			<td>Additional volumes to be added to the results-cache pod (applies to both memcached and exporter containers). Example: extraVolumes: - name: extra-volume   secret:    secretName: extra-volume-secret</td>
 			<td><pre lang="json">
 []
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>resultsCache.host</td>
+			<td>string</td>
+			<td>Hostname for memcached service to use.</td>
+			<td><pre lang="json">
+""
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -26,6 +26,15 @@ Entries should include a reference to the pull request that introduced the chang
 - [BUGFIX] Ensure global.extraEnv and global.extraEnvFrom applied to all resources consistently ([#16828](https://github.com/grafana/loki/pull/16828))
 - [BUGFIX] Fixed statement logic to enable annotations for deployment-gateway, deployment-read, and statefulset-write
 - [BUGFIX] Fix `extraArgs`, `extraVolumes`, `extraVolumeMounts` global values.
+- [FEATURE] Add config support for external memcache cluster by setting the following config:
+    memcached:
+        enabled: false
+    resultsCache:
+        host: 'my-resultsCache-memcached-host'
+        clientService: 'my-memcached-svc'
+    chunksCache:
+        host: 'my-chunksCache-memcached-host'
+        clientService: 'my-memcached-svc'
 
 ## 6.29.0
 

--- a/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
+++ b/production/helm/loki/templates/chunks-cache/poddisruptionbudget-chunks-cache.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.chunksCache.enabled }}
+
+{{- if and .Values.chunksCache.enabled (.Values.memcached.enabled) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-statefulset.tpl
@@ -8,7 +8,7 @@ valuesSection and component are specified separately because helm prefers camelc
 */}}
 {{- define "loki.memcached.statefulSet" -}}
 {{ with (index $.ctx.Values $.valuesSection) }}
-{{- if .enabled -}}
+{{- if and .enabled (.Values.memcached.enabled) -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -177,4 +177,3 @@ spec:
 {{- end -}}
 {{- end -}}
 {{- end -}}
-

--- a/production/helm/loki/templates/memcached/_memcached-svc.tpl
+++ b/production/helm/loki/templates/memcached/_memcached-svc.tpl
@@ -8,7 +8,7 @@ valuesSection and component are specified separately because helm prefers camelc
 */}}
 {{- define "loki.memcached.service" -}}
 {{ with (index $.ctx.Values $.valuesSection) }}
-{{- if .enabled -}}
+{{- if and .enabled (.Values.memcached.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
+++ b/production/helm/loki/templates/results-cache/poddisruptionbudget-results-cache.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.resultsCache.enabled }}
+{{- if and .Values.resultsCache.enabled (.Values.memcached.enabled) }}
 apiVersion: {{ include "loki.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -207,7 +207,9 @@ loki:
           batch_size: {{ .batchSize }}
           parallelism: {{ .parallelism }}
         memcached_client:
-          addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-chunks-cache.{{ $.Release.Namespace }}.svc
+          host: {{ .host }}
+          service: {{ .clientService }}
+          addresses: {{ .addresses }}
           consistent_hash: true
           timeout: {{ .timeout }}
           max_idle_conns: 72
@@ -255,8 +257,10 @@ loki:
             writeback_buffer: {{ .writebackBuffer }}
             writeback_size_limit: {{ .writebackSizeLimit }}
           memcached_client:
+            host: {{ .host }}
+            service: {{ .clientService }}
+            addresses: {{ .addresses }}
             consistent_hash: true
-            addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-results-cache.{{ $.Release.Namespace }}.svc
             timeout: {{ .timeout }}
             update_interval: 1m
       {{- end }}
@@ -3188,7 +3192,10 @@ overridesExporter:
   appProtocol:
     grpc: ""
 
+# You can use a self hosted memcached by setting enabled to false and providing host and clientService
 memcached:
+  # -- Enable the built in memcached server provided by the chart
+  enabled: true
   image:
     # -- Memcached Docker image repository
     repository: memcached
@@ -3239,6 +3246,12 @@ memcachedExporter:
 resultsCache:
   # -- Specifies whether memcached based results-cache should be enabled
   enabled: true
+  # -- Hostname for memcached service to use.
+  host: ""
+  # -- SRV service used to discover memcache servers.
+  clientService: "memcached"
+  # -- Comma separated addresses list in DNS Service Discovery format
+  addresses: dnssrvnoa+_memcached-client._tcp.{{ template "loki.fullname" $ }}-results-cache.{{ $.Release.Namespace }}.svc
   # -- Specify how long cached results should be stored in the results-cache before being expired
   defaultValidity: 12h
   # -- Memcached operation timeout
@@ -3337,6 +3350,12 @@ resultsCache:
 chunksCache:
   # -- Specifies whether memcached based chunks-cache should be enabled
   enabled: true
+  # -- Hostname for memcached service to use.
+  host: ""
+  # -- SRV service used to discover memcache servers.
+  clientService: "memcached"
+  # -- Comma separated addresses list in DNS Service Discovery format
+  addresses: dnssrvnoa+_memcached-client._tcp.{{ template \"loki.fullname\" $ }}-chunks-cache.{{ $.Release.Namespace }}.svc
   # -- Batchsize for sending and receiving chunks from chunks cache
   batchSize: 4
   # -- Parallel threads for sending and receiving chunks from chunks cache


### PR DESCRIPTION
## Summary
Add config support for external memcache cluster by setting the following config
    memcached:
        enabled: false
    resultsCache:
        host: 'my-resultsCache-memcached-host'
        clientService: 'my-memcached-svc'
    chunksCache:
        host: 'my-chunksCache-memcached-host'
        clientService: 'my-memcached-svc'